### PR TITLE
Add seabird-sent events to event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Auth tokens must be sent in the Authorization header (sometimes exposed as the r
 Authorization: Bearer <auth token>
 ```
 
-Auth tokens need to be manually configured on the server side.
+Auth tokens need to be manually configured on the server side. Each token can only refer to a single user, but a user can have multiple tokens.
+
+Currently, the only reserved usernames are `seabird` and `core`.
 
 ## What is "core"?
 

--- a/seabird.proto
+++ b/seabird.proto
@@ -35,7 +35,7 @@ message Event {
 // client sending the message.
 message SendMessageEvent {
   string sender = 1;
-  common.MessageEvent event = 2;
+  SendMessageRequest inner = 2;
 }
 
 // SendPrivateMessageEvent will be emitted whenever a plugin or other client
@@ -44,7 +44,7 @@ message SendMessageEvent {
 // param refers to the client sending the message.
 message SendPrivateMessageEvent {
   string sender = 1;
-  common.PrivateMessageEvent event = 2;
+  SendPrivateMessageRequest inner = 2;
 }
 
 // PerformActionEvent will be emitted whenever a plugin or other client calls
@@ -53,7 +53,7 @@ message SendPrivateMessageEvent {
 // client sending the message.
 message PerformActionEvent {
   string sender = 1;
-  common.ActionEvent event = 2;
+  PerformActionRequest inner = 2;
 }
 
 // PerformPrivateActionEvent will be emitted whenever a plugin or other client
@@ -62,7 +62,7 @@ message PerformActionEvent {
 // param refers to the client sending the message.
 message PerformPrivateActionEvent {
   string sender = 1;
-  common.PrivateActionEvent event = 2;
+  PerformPrivateActionRequest inner = 2;
 }
 
 // Request and response objects

--- a/seabird.proto
+++ b/seabird.proto
@@ -12,6 +12,7 @@ import "common.proto";
 
 message Event {
   oneof inner {
+    // Events sent by chat backends.
     common.MessageEvent message = 1;
     common.PrivateMessageEvent private_message = 2;
     common.MentionEvent mention = 3;
@@ -19,11 +20,49 @@ message Event {
     common.ActionEvent action = 5;
     common.PrivateActionEvent private_action = 6;
 
-    SendMessageRequest core_message = 7;
-    SendPrivateMessageRequest core_private_message = 8;
-    PerformActionRequest core_action = 9;
-    PerformPrivateActionRequest core_private_action = 10;
+    // Events sent by plugins and other clients. Generally, these are only
+    // needed for special cases.
+    SendMessageEvent send_message = 7;
+    SendPrivateMessageEvent send_private_message = 8;
+    PerformActionEvent perform_action = 9;
+    PerformPrivateActionEvent perform_private_action = 10;
   }
+}
+
+// SendMessageEvent will be emitted whenever a plugin or other client calls
+// SendMessage. Note that this will be emitted every time SendMessage is
+// called, not when it succeeds. The additional sender param refers to the
+// client sending the message.
+message SendMessageEvent {
+  string sender = 1;
+  common.MessageEvent event = 2;
+}
+
+// SendPrivateMessageEvent will be emitted whenever a plugin or other client
+// calls SendPrivateMessage. Note that this will be emitted every time
+// SendPrivateMessage is called, not when it succeeds.The additional sender
+// param refers to the client sending the message.
+message SendPrivateMessageEvent {
+  string sender = 1;
+  common.PrivateMessageEvent event = 2;
+}
+
+// PerformActionEvent will be emitted whenever a plugin or other client calls
+// PerformAction. Note that this will be emitted every time PerformAction is
+// called, not when it succeeds. The additional sender param refers to the
+// client sending the message.
+message PerformActionEvent {
+  string sender = 1;
+  common.ActionEvent event = 2;
+}
+
+// PerformPrivateActionEvent will be emitted whenever a plugin or other client
+// calls PerformPrivateAction. Note that this will be emitted every time
+// PerformPrivateAction is called, not when it succeeds. The additional sender
+// param refers to the client sending the message.
+message PerformPrivateActionEvent {
+  string sender = 1;
+  common.PrivateActionEvent event = 2;
 }
 
 // Request and response objects

--- a/seabird.proto
+++ b/seabird.proto
@@ -15,6 +15,8 @@ message Event {
     common.PrivateMessageEvent private_message = 2;
     common.MentionEvent mention = 3;
     common.CommandEvent command = 4;
+    SendMessageRequest core_message = 5;
+    SendPrivateMessageRequest core_private_message = 6;
   }
 }
 


### PR DESCRIPTION
This does still need more work - I've got a few questions about how we want to do it.

1. Should there be different events other than the already existing SendMessageRequest and SendPrivateMessageRequest? If yes, they could be called CoreMessageEvent and CorePrivateMessageEvent.
2. What are all the expectations around this?
    - Should plugins get events they sent? Is this determined based on the key used to auth with the service?
    - What happens if there are multiple event streams for a single key?
    - Will only "successful" events be broadcasted? What happens if an event times out but a success comes in later?

Documentation also needs to be added.