### PR TITLE
Add protobuf plumbing for fetching backend config

### DIFF
--- a/seabird.proto
+++ b/seabird.proto
@@ -158,6 +158,14 @@ message BackendInfoResponse {
   common.Backend Backend = 1;
 }
 
+message BackendConfigRequest {
+  string backend_id = 1;
+}
+
+message BackendConfigResponse {
+  map<string, string> config = 1;
+}
+
 message ListChannelsRequest {
   string backend_id = 1;
 }
@@ -204,6 +212,7 @@ service Seabird {
   // Chat backend introspection
   rpc ListBackends(ListBackendsRequest) returns (ListBackendsResponse);
   rpc GetBackendInfo(BackendInfoRequest) returns (BackendInfoResponse);
+  rpc GetBackendConfig(BackendConfigRequest) returns (BackendConfigResponse);
 
   // Chat connection introspection
   rpc ListChannels(ListChannelsRequest) returns (ListChannelsResponse);

--- a/seabird.proto
+++ b/seabird.proto
@@ -156,14 +156,7 @@ message BackendInfoRequest {
 
 message BackendInfoResponse {
   common.Backend Backend = 1;
-}
-
-message BackendConfigRequest {
-  string backend_id = 1;
-}
-
-message BackendConfigResponse {
-  map<string, string> config = 1;
+  map<string, string> config = 2;
 }
 
 message ListChannelsRequest {
@@ -212,7 +205,6 @@ service Seabird {
   // Chat backend introspection
   rpc ListBackends(ListBackendsRequest) returns (ListBackendsResponse);
   rpc GetBackendInfo(BackendInfoRequest) returns (BackendInfoResponse);
-  rpc GetBackendConfig(BackendConfigRequest) returns (BackendConfigResponse);
 
   // Chat connection introspection
   rpc ListChannels(ListChannelsRequest) returns (ListChannelsResponse);

--- a/seabird.proto
+++ b/seabird.proto
@@ -156,7 +156,7 @@ message BackendInfoRequest {
 
 message BackendInfoResponse {
   common.Backend Backend = 1;
-  map<string, string> config = 2;
+  map<string, string> metadata = 2;
 }
 
 message ListChannelsRequest {

--- a/seabird_chat_ingest.proto
+++ b/seabird_chat_ingest.proto
@@ -142,7 +142,7 @@ message ChangeChannelChatEvent {
 // MetadataChatEvent will be sent in response to a MetadataChatRequest. It
 // is not sent directly without a corresponding request from seabird-core.
 message MetadataChatEvent {
-  map<string, string> config = 1;
+  map<string, string> values = 1;
 }
 
 // ChatEvent contains all the different event types a chat backend can emit.

--- a/seabird_chat_ingest.proto
+++ b/seabird_chat_ingest.proto
@@ -68,6 +68,8 @@ message UpdateChannelInfoChatRequest {
   string topic = 2;
 }
 
+message GetConfigChatRequest {}
+
 // Each ChatRequest has an ID (which can be attached to requests coming from
 // core) and an inner message type. Having an ID allows us to route an event
 // back to the requestor without having the chat backend implement a service.
@@ -85,6 +87,7 @@ message ChatRequest {
     UpdateChannelInfoChatRequest update_channel_info = 6;
     PerformActionChatRequest perform_action = 7;
     PerformPrivateActionChatRequest perform_private_action = 8;
+    GetConfigChatRequest get_config = 9;
   }
 }
 
@@ -134,6 +137,10 @@ message ChangeChannelChatEvent {
   string topic = 3;
 }
 
+message ConfigChatEvent {
+  map<string, string> config = 1;
+}
+
 // ChatEvent contains all the different event types a chat backend can emit.
 // Note that these are slightly different to the seabird.Event types as channels
 // here will not be mapped to UUIDs and some events are only to support the data
@@ -167,6 +174,9 @@ message ChatEvent {
     JoinChannelChatEvent join_channel = 9;
     LeaveChannelChatEvent leave_channel = 10;
     ChangeChannelChatEvent change_channel = 11;
+
+    // Introspection
+    ConfigChatEvent config = 14;
   }
 }
 

--- a/seabird_chat_ingest.proto
+++ b/seabird_chat_ingest.proto
@@ -68,7 +68,9 @@ message UpdateChannelInfoChatRequest {
   string topic = 2;
 }
 
-message GetConfigChatRequest {}
+// MetadataChatRequest requests metadata about the given backend. seabird-core
+// expects the backend to respond with a MetadataChatEvent object.
+message MetadataChatRequest {}
 
 // Each ChatRequest has an ID (which can be attached to requests coming from
 // core) and an inner message type. Having an ID allows us to route an event
@@ -87,7 +89,7 @@ message ChatRequest {
     UpdateChannelInfoChatRequest update_channel_info = 6;
     PerformActionChatRequest perform_action = 7;
     PerformPrivateActionChatRequest perform_private_action = 8;
-    GetConfigChatRequest get_config = 9;
+    MetadataChatRequest metadata = 9;
   }
 }
 
@@ -137,7 +139,9 @@ message ChangeChannelChatEvent {
   string topic = 3;
 }
 
-message ConfigChatEvent {
+// MetadataChatEvent will be sent in response to a MetadataChatRequest. It
+// is not sent directly without a corresponding request from seabird-core.
+message MetadataChatEvent {
   map<string, string> config = 1;
 }
 
@@ -176,7 +180,7 @@ message ChatEvent {
     ChangeChannelChatEvent change_channel = 11;
 
     // Introspection
-    ConfigChatEvent config = 14;
+    MetadataChatEvent metadata = 14;
   }
 }
 


### PR DESCRIPTION
This change adds the protobuf setup for plugins to fetch backend
configuration via core. Followup PRs on a few seabird-chat repos will
show usage.