### PR TITLE
Initial message block design

### DIFF
--- a/common.proto
+++ b/common.proto
@@ -160,12 +160,16 @@ message Block {
     ItalicsBlock italics = 4;
     BoldBlock bold = 5;
     UnderlineBlock underline = 6;
-    ColorBlock color = 7;
-    MentionBlock mention = 8;
-    SpoilerBlock spoiler = 9;
-    ActionBlock action = 10;
-    ListBlock list = 11;
-    LinkBlock link = 12;
+    StrikethroughBlock strikethrough = 7;
+    InlineCodeBlock inline_code = 8;
+    FencedCodeBlock fenced_code = 9;
+    ColorBlock color = 10;
+    MentionBlock mention = 11;
+    SpoilerBlock spoiler = 12;
+    ActionBlock action = 13;
+    ListBlock list = 14;
+    LinkBlock link = 15;
+    BlockquoteBlock blockquote = 16;
   }
 }
 
@@ -190,6 +194,25 @@ message BoldBlock {
 // inside it.
 message UnderlineBlock {
   repeated Block inner = 1;
+}
+
+// StrikethroughBlock is a formatting block, applying the formatting to all blocks
+// inside it.
+message StrikethroughBlock {
+  repeated Block inner = 1;
+}
+
+// InlineCodeBlock is a formatting block, applying the formatting to all blocks
+// inside it.
+message InlineCodeBlock {
+  string text = 1;
+}
+
+// FencedCodeBlock is a formatting block, applying the formatting to all blocks
+// inside it.
+message FencedCodeBlock {
+  string info = 1;
+  string text = 2;
 }
 
 message Color {
@@ -243,4 +266,10 @@ message ListBlock {
 message LinkBlock {
   string url = 1;
   repeated Block inner = 2;
+}
+
+// BlockquoteBlock is a container block, signifying that the inner blocks are
+// all in a blockquote.
+message BlockquoteBlock {
+  repeated Block inner = 1;
 }

--- a/common.proto
+++ b/common.proto
@@ -159,12 +159,13 @@ message Block {
     TextBlock text = 3;
     ItalicsBlock italics = 4;
     BoldBlock bold = 5;
-    ColorBlock color = 6;
-    MentionBlock mention = 7;
-    SpoilerBlock spoiler = 8;
-    ActionBlock action = 9;
-    ListBlock list = 10;
-    LinkBlock link = 11;
+    UnderlineBlock underline = 6;
+    ColorBlock color = 7;
+    MentionBlock mention = 8;
+    SpoilerBlock spoiler = 9;
+    ActionBlock action = 10;
+    ListBlock list = 11;
+    LinkBlock link = 12;
   }
 }
 
@@ -182,6 +183,12 @@ message ItalicsBlock {
 // BoldBlock is a formatting block, applying the formatting to all blocks
 // inside it.
 message BoldBlock {
+  repeated Block inner = 1;
+}
+
+// UnderlineBlock is a formatting block, applying the formatting to all blocks
+// inside it.
+message UnderlineBlock {
   repeated Block inner = 1;
 }
 

--- a/common.proto
+++ b/common.proto
@@ -233,7 +233,7 @@ message ActionBlock {
 // ListBlock is a container block, signifying that the inner blocks are all list
 // items.
 message ListBlock {
-  repeated Block items = 1;
+  repeated Block inner = 1;
 }
 
 // LinkBlock represents a link. The URL is the URL, and the inner blocks are the

--- a/common.proto
+++ b/common.proto
@@ -146,23 +146,30 @@ message Block {
   // the inner block, while allowing existing clients to fall back to the raw
   // string.
   //
-  // If a client does not include the "raw" property, it will be re-hydrated by
-  // seabird-core.
+  // If a client does not include the "raw" or "plain" properties, they will be
+  // re-hydrated by seabird-core.
+
+  // The input text
   string raw = 1;
 
+  // The parsed text with all formatting removed
+  string plain = 2;
+
   oneof inner {
-    PlainBlock plain = 2;
-    ItalicsBlock italics = 3;
-    BoldBlock bold = 4;
-    ColorBlock color = 5;
-    MentionBlock mention = 6;
-    SpoilerBlock spoiler = 7;
-    ActionBlock action = 8;
+    TextBlock text = 3;
+    ItalicsBlock italics = 4;
+    BoldBlock bold = 5;
+    ColorBlock color = 6;
+    MentionBlock mention = 7;
+    SpoilerBlock spoiler = 8;
+    ActionBlock action = 9;
+    ListBlock list = 10;
+    LinkBlock link = 11;
   }
 }
 
-// PlainBlock is a simple text block. It does not have any child blocks.
-message PlainBlock {
+// TextBlock is a simple text block. It does not have any child blocks.
+message TextBlock {
   string text = 1;
 }
 
@@ -216,4 +223,17 @@ message SpoilerBlock {
 // be ignored.
 message ActionBlock {
   repeated Block inner = 1;
+}
+
+// ListBlock is a container block, signifying that the inner blocks are all list
+// items.
+message ListBlock {
+  repeated Block items = 1;
+}
+
+// LinkBlock represents a link. The URL is the URL, and the inner blocks are the
+// link text.
+message LinkBlock {
+  string url = 1;
+  repeated Block inner = 2;
 }

--- a/common.proto
+++ b/common.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package common;
 
+import "google/protobuf/timestamp.proto";
+
 option java_package = "io.coded.seabird.common";
 option go_package = ".;pb";
 
@@ -89,6 +91,13 @@ message ChannelSource {
 // Common Events
 
 // MessageEvent will be sent when a user sends a message to a channel.
+//
+// When ingesting, if blocks are provided, they will be used to re-hydrate the
+// text string. If only text is provided, a new TextBlock with the text contents
+// will be created.
+//
+// Clients can assume that both text and blocks will be provided for every
+// message.
 message MessageEvent {
   ChannelSource source = 1;
   string text = 2;
@@ -165,6 +174,7 @@ message Block {
     ListBlock list = 12;
     LinkBlock link = 13;
     BlockquoteBlock blockquote = 14;
+    TimestampBlock timestamp = 15;
   }
 }
 
@@ -247,4 +257,10 @@ message LinkBlock {
 // all in a blockquote.
 message BlockquoteBlock {
   repeated Block inner = 1;
+}
+
+// TimestampBlock represents a timestamp. It can be used on platforms which
+// support timezone-aware timestamps.
+message TimestampBlock {
+  google.protobuf.Timestamp inner = 1;
 }

--- a/common.proto
+++ b/common.proto
@@ -92,6 +92,7 @@ message ChannelSource {
 message MessageEvent {
   ChannelSource source = 1;
   string text = 2;
+  repeated Block blocks = 3;
 }
 
 // PrivateMessageEvent will be sent when a user sends a message directly to the
@@ -99,19 +100,22 @@ message MessageEvent {
 message PrivateMessageEvent {
   common.User source = 1;
   string text = 2;
+  repeated Block blocks = 3;
 }
 
 // MentionEvent will be sent when a user mentions the chat backend's user at the
-// start of a message in a channel. Note that this may eventually go away when a
-// more general message format is developed.
+// start of a message in a channel.
+//
+// This has been deprecated in favor of MessageEvents containing a MentionBlock.
 message MentionEvent {
   ChannelSource source = 1;
   string text = 2;
+  repeated Block blocks = 3;
 }
 
 // CommandEvent will be sent when a user issues a command in a channel. Commands
-// cannot be issued via private message. If a message is parsed as a command, it
-// MUST NOT be also sent as another message type.
+// cannot currently be issued via private message. If a message is parsed as a
+// command, it MUST NOT be also sent as another message type.
 message CommandEvent {
   ChannelSource source = 1;
   string command = 2;
@@ -120,9 +124,12 @@ message CommandEvent {
 
 // ActionEvent will be sent when a user takes an action in a channel. This is
 // often triggered with /me.
+//
+// This has been deprecated in favor of MessageEvents containing an ActionBlock.
 message ActionEvent {
   ChannelSource source = 1;
   string text = 2;
+  repeated Block blocks = 3;
 }
 
 // PrivateActionEvent will be sent when a user takes an action in a private
@@ -130,4 +137,83 @@ message ActionEvent {
 message PrivateActionEvent {
   common.User source = 1;
   string text = 2;
+  repeated Block blocks = 3;
+}
+
+// Block defines the base message format. It is essentially a tree
+message Block {
+  // Having a raw string on the Block type allows us to add additional types to
+  // the inner block, while allowing existing clients to fall back to the raw
+  // string.
+  //
+  // If a client does not include the "raw" property, it will be re-hydrated by
+  // seabird-core.
+  string raw = 1;
+
+  oneof inner {
+    PlainBlock plain = 2;
+    ItalicsBlock italics = 3;
+    BoldBlock bold = 4;
+    ColorBlock color = 5;
+    MentionBlock mention = 6;
+    SpoilerBlock spoiler = 7;
+    ActionBlock action = 8;
+  }
+}
+
+// PlainBlock is a simple text block. It does not have any child blocks.
+message PlainBlock {
+  string text = 1;
+}
+
+// ItalicsBlock is a formatting block, applying the formatting to all blocks
+// inside it.
+message ItalicsBlock {
+  repeated Block inner = 1;
+}
+
+// BoldBlock is a formatting block, applying the formatting to all blocks
+// inside it.
+message BoldBlock {
+  repeated Block inner = 1;
+}
+
+message Color {
+  // Each value is a float in the range [0, 1] representing a color component.
+
+  // Red, Green, Blue
+  float r = 1;
+  float g = 2;
+  float b = 3;
+
+  // Alpha
+  float a = 4;
+}
+
+// ColorBlock is a formatting block, applying the formatting to all blocks
+// inside it.
+message ColorBlock {
+  Color color = 1;
+
+  repeated Block inner = 3;
+}
+
+// MentionBlock is a simple text block containing only a mentioned user. It does
+// not have any child blocks.
+message MentionBlock {
+  User user = 1;
+}
+
+// SpoilerBlock is a formatting block, applying the formatting to all blocks
+// inside it.
+message SpoilerBlock {
+  repeated Block inner = 2;
+}
+
+// ActionBlock is a root container block, signifying that the inner blocks are a
+// part of an "action", usually from /me on IRC. A message is only a valid
+// action if the only root level block is an action. Any nested ActionBlocks can
+// be ignored.
+message ActionBlock {
+  repeated Block inner = 1;
 }

--- a/common.proto
+++ b/common.proto
@@ -146,30 +146,25 @@ message Block {
   // the inner block, while allowing existing clients to fall back to the raw
   // string.
   //
-  // If a client does not include the "raw" or "plain" properties, they will be
-  // re-hydrated by seabird-core.
-
-  // The input text
-  string raw = 1;
+  // Seabird will always re-hydrate the "plain" property from the blocks.
 
   // The parsed text with all formatting removed
-  string plain = 2;
+  string plain = 1;
 
   oneof inner {
-    TextBlock text = 3;
-    ItalicsBlock italics = 4;
-    BoldBlock bold = 5;
-    UnderlineBlock underline = 6;
-    StrikethroughBlock strikethrough = 7;
-    InlineCodeBlock inline_code = 8;
-    FencedCodeBlock fenced_code = 9;
-    ColorBlock color = 10;
-    MentionBlock mention = 11;
-    SpoilerBlock spoiler = 12;
-    ActionBlock action = 13;
-    ListBlock list = 14;
-    LinkBlock link = 15;
-    BlockquoteBlock blockquote = 16;
+    TextBlock text = 2;
+    ItalicsBlock italics = 3;
+    BoldBlock bold = 4;
+    UnderlineBlock underline = 5;
+    StrikethroughBlock strikethrough = 6;
+    InlineCodeBlock inline_code = 7;
+    FencedCodeBlock fenced_code = 8;
+    MentionBlock mention = 9;
+    SpoilerBlock spoiler = 10;
+    ActionBlock action = 11;
+    ListBlock list = 12;
+    LinkBlock link = 13;
+    BlockquoteBlock blockquote = 14;
   }
 }
 
@@ -213,26 +208,6 @@ message InlineCodeBlock {
 message FencedCodeBlock {
   string info = 1;
   string text = 2;
-}
-
-message Color {
-  // Each value is a float in the range [0, 1] representing a color component.
-
-  // Red, Green, Blue
-  float r = 1;
-  float g = 2;
-  float b = 3;
-
-  // Alpha
-  float a = 4;
-}
-
-// ColorBlock is a formatting block, applying the formatting to all blocks
-// inside it.
-message ColorBlock {
-  Color color = 1;
-
-  repeated Block inner = 3;
 }
 
 // MentionBlock is a simple text block containing only a mentioned user. It does

--- a/seabird.proto
+++ b/seabird.proto
@@ -111,6 +111,7 @@ message PerformPrivateActionEvent {
 message SendMessageRequest {
   string channel_id = 1;
   string text = 2;
+  repeated common.Block blocks = 4;
 
   map<string, string> tags = 3;
 }

--- a/seabird.proto
+++ b/seabird.proto
@@ -63,6 +63,7 @@ message CommandMetadata {
 message PerformActionRequest {
   string channel_id = 1;
   string text = 2;
+  repeated common.Block blocks = 4;
 
   map<string, string> tags = 3;
 }
@@ -79,12 +80,14 @@ message PerformActionEvent {
 
   string channel_id = 2;
   string text = 3;
+  repeated common.Block blocks = 4;
 }
 
 // Perform an action in a private message.
 message PerformPrivateActionRequest {
   string user_id = 1;
   string text = 2;
+  repeated common.Block blocks = 4;
 
   map<string, string> tags = 3;
 }
@@ -101,6 +104,7 @@ message PerformPrivateActionEvent {
 
   string user_id = 2;
   string text = 3;
+  repeated common.Block blocks = 4;
 }
 
 // Send a message to a given a channel.
@@ -123,12 +127,14 @@ message SendMessageEvent {
 
   string channel_id = 2;
   string text = 3;
+  repeated common.Block blocks = 4;
 }
 
 // Send a private message to a given user.
 message SendPrivateMessageRequest {
   string user_id = 1;
   string text = 2;
+  repeated common.Block blocks = 4;
 
   map<string, string> tags = 3;
 }
@@ -145,6 +151,7 @@ message SendPrivateMessageEvent {
 
   string user_id = 2;
   string text = 3;
+  repeated common.Block blocks = 4;
 }
 
 // Request to join a channel.

--- a/seabird_chat_ingest.proto
+++ b/seabird_chat_ingest.proto
@@ -18,6 +18,7 @@ option go_package = ".;pb";
 message PerformActionChatRequest {
   string channel_id = 1;
   string text = 2;
+  repeated common.Block blocks = 4;
 
   map<string, string> tags = 3;
 }
@@ -29,6 +30,7 @@ message PerformActionChatRequest {
 message PerformPrivateActionChatRequest {
   string user_id = 1;
   string text = 2;
+  repeated common.Block blocks = 4;
 
   map<string, string> tags = 3;
 }
@@ -40,6 +42,7 @@ message PerformPrivateActionChatRequest {
 message SendMessageChatRequest {
   string channel_id = 1;
   string text = 2;
+  repeated common.Block blocks = 4;
 
   map<string, string> tags = 3;
 }
@@ -51,6 +54,7 @@ message SendMessageChatRequest {
 message SendPrivateMessageChatRequest {
   string user_id = 1;
   string text = 2;
+  repeated common.Block blocks = 4;
 
   map<string, string> tags = 3;
 }


### PR DESCRIPTION
This is an initial proposal/attempt to add a message-block format for seabird messages.

The Block type defines a tree which can be used in messages.

There are 3 base types of blocks:

- Leaf blocks with no children (PlainBlock, MentionBlock)
- Formatting block which applies its formatting to all child blocks
- Marker blocks which mark a message as a specific type (Currently only ActionBlock)

When a message is submitted without blocks (but with the raw text set), it will be hydrated into a PlainBlock containing the text by seabird-core.

When a message is submitted with blocks, the raw text will be overwritten with a markdown-esque version of the blocks.